### PR TITLE
rzv2h: Support board id file in .bin format

### DIFF
--- a/universal-scripts/host/tools/config/boards_flash_config.toml
+++ b/universal-scripts/host/tools/config/boards_flash_config.toml
@@ -82,7 +82,7 @@ load_address = "0x48000000"
 [rzv2h-evk.qspi]
 BL2 = ["8101E00", "00000"]
 FIP = ["00000", "60000"]
-BID = ["00000", "120000"]
+BID = ["00810", "120000"]
 
 # Bootloader flash eMMC
 [rzv2h-evk.emmc]

--- a/universal-scripts/host/tools/flash_images.json
+++ b/universal-scripts/host/tools/flash_images.json
@@ -28,7 +28,7 @@
     },
     "rzv2h-evk": {
         "bl2": "bl2_bp_spi_rzv2h-evk.srec",
-        "board_identification": "rzv2h-evk-platform-settings.srec",
+        "board_identification": "rzv2h-evk-platform-settings.bin",
         "fip": "fip_rzv2h-evk.srec",
         "flash_writer": "Flash_Writer_SCIF_RZV2H_DEV_INTERNAL_MEMORY.mot",
         "ipl_flash_method": "qspi",


### PR DESCRIPTION
Flash Writer now supports flashing Board ID files in .bin format instead of .srec format.