### PR TITLE
universal-scripts: Fix arguments parser and correct image default value

### DIFF
--- a/universal-scripts/host/tools/README.md
+++ b/universal-scripts/host/tools/README.md
@@ -46,7 +46,7 @@ Example of a sample board configuration in JSON:
 
 ```json
 "rzg2l-sbc": {
-    "bl2": "bl2_bp-rzg2l-sbc.srec",
+    "bl2": "bl2_bp_rzg2l-sbc.srec",
     "board_identification": "rzg2l-sbc-platform-settings.bin",
     "fip": "fip-rzg2l-sbc.srec",
     "flash_writer": "Flash_Writer_SCIF_rzg2l-sbc.mot",

--- a/universal-scripts/host/tools/bootloader_flasher/README.md
+++ b/universal-scripts/host/tools/bootloader_flasher/README.md
@@ -35,7 +35,7 @@ Place all bootloader images (e.g., for RZG2L-SBC board) in the /path/to/universa
 ```bash
 mkdir -p /path/to/universal-scripts/target/images/
 cp /path/to/your/bootloader/file/Flash_Writer_SCIF_rzg2l-sbc.mot /path/to/universal-scripts/target/images/
-cp /path/to/your/bootloader/file/bl2_bp-rzg2l-sbc.srec /path/to/universal-scripts/target/images/
+cp /path/to/your/bootloader/file/bl2_bp_rzg2l-sbc.srec /path/to/universal-scripts/target/images/
 cp /path/to/your/bootloader/file/fip-rzg2l-sbc.srec /path/to/universal-scripts/target/images/
 cp /path/to/your/bootloader/file/rzg2l-sbc-platform-settings.bin /path/to/universal-scripts/target/images/
 ```
@@ -67,7 +67,7 @@ When no arguments are provided, the script will use the following default info:
 - Serial port: most recently connected port (E.g: COM8 in Windows or /dev/ttyUSB0 in Linux)
 - Serial port baud: 115200
 - Flash Writer Image: /path/to/universal-scripts/target/images/Flash_Writer_SCIF_rzg2l-sbc.mot
-- BL2 Image: /path/to/universal-scripts/target/images/bl2_bp-rzg2l-sbc.srec
+- BL2 Image: /path/to/universal-scripts/target/images/bl2_bp_rzg2l-sbc.srec
 - FIP Image: /path/to/universal-scripts/target/images/fip-rzg2l-sbc.srec
 - Board identification Image: /path/to/universal-scripts/target/images/rzg2l-sbc-platform-settings.bin
 
@@ -91,13 +91,13 @@ Example Custom Command
 - Windows:
 
 ```
-py bootloader_flash.py --board_name rzg2l-evk --flash_method emmc --serial_port COM11 --serial_port_baud 9600 --image_writer D:\custom_images\Flash_Writer_SCIF_rzg2l-sbc.mot --image_bl2 D:\custom_images\bl2_bp-rzg2l-sbc.srec --image_fip D:\custom_images\fip-rzg2l-sbc.srec --image_bid D:\custom_images\rzg2l-evk-platform-settings.bin
+py bootloader_flash.py --board_name rzg2l-evk --flash_method emmc --serial_port COM11 --serial_port_baud 9600 --image_writer D:\custom_images\Flash_Writer_SCIF_rzg2l-sbc.mot --image_bl2 D:\custom_images\bl2_bp_rzg2l-sbc.srec --image_fip D:\custom_images\fip-rzg2l-sbc.srec --image_bid D:\custom_images\rzg2l-evk-platform-settings.bin
 ```
 
 - Linux:
 
 ```
-python3 bootloader_flash.py --board_name rzg2l-evk --flash_method emmc --serial_port /dev/ttyUSB0 --serial_port_baud 9600 --image_writer /home/renesas/custom_images/Flash_Writer_SCIF_rzg2l-sbc.mot --image_bl2 /home/renesas/custom_images/bl2_bp-rzg2l-sbc.srec --image_fip /home/renesas/custom_images/fip-rzg2l-sbc.srec --image_bid /home/renesas/custom_images/rzg2l-evk-platform-settings.bin
+python3 bootloader_flash.py --board_name rzg2l-evk --flash_method emmc --serial_port /dev/ttyUSB0 --serial_port_baud 9600 --image_writer /home/renesas/custom_images/Flash_Writer_SCIF_rzg2l-sbc.mot --image_bl2 /home/renesas/custom_images/bl2_bp_rzg2l-sbc.srec --image_fip /home/renesas/custom_images/fip-rzg2l-sbc.srec --image_bid /home/renesas/custom_images/rzg2l-evk-platform-settings.bin
 ```
 
 **3. Power on the board. It will start to flash bootloader images**

--- a/universal-scripts/host/tools/bootloader_flasher/bootloader_flash.py
+++ b/universal-scripts/host/tools/bootloader_flasher/bootloader_flash.py
@@ -138,7 +138,7 @@ class BootloaderFlashUtil:
 
 			time.sleep(0.1)
 
-		print(f'{buffer.decode()}')
+		print(f'{buffer.decode(errors="ignore")}')
 
 	# Function to write bootloader
 	def writeBootloader(self):
@@ -350,7 +350,7 @@ class BootloaderFlashUtil:
 			print(f"Returned value {cond} is not the expectation. Exiting.")
 			exit()
 
-		print(f'{buf.decode()}')
+		print(f'{buf.decode(errors="ignore")}')
 
 # Util function to die with error
 def die(msg='', code=1):

--- a/universal-scripts/host/tools/bootloader_flasher/bootloader_flash.py
+++ b/universal-scripts/host/tools/bootloader_flasher/bootloader_flash.py
@@ -64,11 +64,11 @@ class BootloaderFlashUtil:
 									type=str,
 									help="Path to Flash Writer image (defaults to: <path/to/your/package>/target/images/Flash_Writer_SCIF_rzg2l-sbc.mot).")
 		self.__parser.add_argument('--image_bl2',
-									default=f'{self.__imagesDir}/bl2_bp-rzg2l-sbc.srec',
+									default=f'{self.__imagesDir}/bl2_bp_rzg2l-sbc.srec',
 									dest='bl2Image',
 									action='store',
 									type=str,
-									help='Path to bl2 image (defaults to: <path/to/your/package>/target/images/bl2_bp-rzg2l-sbc.srec).')
+									help='Path to bl2 image (defaults to: <path/to/your/package>/target/images/bl2_bp_rzg2l-sbc.srec).')
 		self.__parser.add_argument('--image_fip',
 									default=f'{self.__imagesDir}/fip-rzg2l-sbc.srec',
 									dest='fipImage',
@@ -82,7 +82,7 @@ class BootloaderFlashUtil:
 									type=str,
 									help='Path to board identification image (defaults to: <path/to/your/package>/target/images/rzg2l-sbc-platform-settings.bin).')
 
-		if args is not None:
+		if args:
 			self.__args = self.__parser.parse_args(args)
 		else:
 			self.__args = self.__parser.parse_args()

--- a/universal-scripts/host/tools/flash_images.json
+++ b/universal-scripts/host/tools/flash_images.json
@@ -18,7 +18,7 @@
         "rootfs_flash_method": "udp"
     },
     "rzg2l-sbc": {
-        "bl2": "bl2_bp-rzg2l-sbc.srec",
+        "bl2": "bl2_bp_rzg2l-sbc.srec",
         "board_identification": "rzg2l-sbc-platform-settings.bin",
         "fip": "fip_rzg2l-sbc.srec",
         "flash_writer": "Flash_Writer_SCIF_rzg2l-sbc.mot",

--- a/universal-scripts/host/tools/sd_creator/sd_flash.py
+++ b/universal-scripts/host/tools/sd_creator/sd_flash.py
@@ -86,7 +86,7 @@ class SdFlashUtil:
 									type=str,
 									help='Path to rootfs (defaults to: <path/to/your/package>/target/images/core-image-qt-rzg2l-sbc.wic).')
 
-		if args is not None:
+		if args:
 			self.__args = self.__parser.parse_args(args)
 		else:
 			self.__args = self.__parser.parse_args()

--- a/universal-scripts/host/tools/sd_creator/sd_flash.py
+++ b/universal-scripts/host/tools/sd_creator/sd_flash.py
@@ -204,7 +204,7 @@ class SdFlashUtil:
 			print("Returned value is not the expectation. Exiting.")
 			exit()
 
-		print(f'{buf.decode()}')
+		print(f'{buf.decode(errors="ignore")}')
 
 # Util function to die with error
 def die(msg='', code=1):

--- a/universal-scripts/host/tools/uload_bootloader/uload_bootloader_flash.py
+++ b/universal-scripts/host/tools/uload_bootloader/uload_bootloader_flash.py
@@ -188,7 +188,7 @@ class UloadFlashUtil:
 			print("Returned value is not the expectation. Exiting.")
 			exit()
 
-		print(f'{buf.decode()}')
+		print(f'{buf.decode(errors="ignore")}')
 
 # Util function to die with error
 def die(msg='', code=1):

--- a/universal-scripts/host/tools/uload_bootloader/uload_bootloader_flash.py
+++ b/universal-scripts/host/tools/uload_bootloader/uload_bootloader_flash.py
@@ -47,7 +47,7 @@ class UloadFlashUtil:
 									type=int,
 									help='Baud rate for serial port (defaults to: 115200).')
 
-		if args is not None:
+		if args:
 			self.__args = self.__parser.parse_args(args)
 		else:
 			self.__args = self.__parser.parse_args()


### PR DESCRIPTION
Change includes:
- Fix the argument parser in subscript to correctly handle the parse arguments.
- Correct the default value for rzg2l-sbc BL2 image.

Signed-off-by: Thanh Nguyen thanh.nguyen.wx@bp.renesas.com