### PR TITLE
local-build-scripts: add support for Distro 3

### DIFF
--- a/local-build-scripts/build_atf.sh
+++ b/local-build-scripts/build_atf.sh
@@ -1,84 +1,117 @@
 #!/bin/bash
+set -euo pipefail
 
 source ./config.ini
 source ./common.sh
 
-# Check ATF location
-if [ -z "${ATF_DIR}" ]; then
-        echo "There is no U-Boot source at ${ATF_DIR} or it does not set properly at config.ini file."
-        echo "Please recheck your setup"
-        exit 1
+# if PLATFORM is already exported from main_build.sh, keep it
+if [ -n "${PLATFORM:-}" ] && [ -n "${PLAT:-}" ]; then
+	PLATFORM="$PLAT"
 fi
 
-# Setup the build
-atf_setup() {
-        unset CFLAGS LDFLAGS
+# Check ATF location
+if [ -z "${ATF_DIR}" ]; then
+	echo "There is no TF-A source at ${ATF_DIR} or it does not set properly at config.ini file."
+	echo "Please recheck your setup"
+	exit 1
+fi
 
-        case ${PLATFORM} in
-                'RZG2L-SBC')
-                        PLAT="g2l"
-                        BOARD="sbc_1"
-                        ;;
-                'RZG2L-EVK')
-                        PLAT="g2l"
-                        BOARD="smarc_pmic_2"
-                        ;;
-                'RZV2L-EVK')
-                        PLAT="v2l"
-                        BOARD="smarc_pmic_2"
-                        ;;
-                'RZV2H-EVK')
-                        PLAT="v2h"
-                        BOARD="evk_1"
-                        ;;
-                *)
-                        echo "The platform does not support. Please recheck your setup" || exit 1
-                        ;;
-        esac        
+# ---- Config ----
+JOBS="${JOBS:-$(nproc)}"
+
+# Map PLATFORM -> "PLAT BOARD"
+declare -A P2B=(
+	["RZG2L-SBC"]="g2l sbc_1"
+	["RZG2L-EVK"]="g2l smarc_pmic_2"
+	["RZV2L-EVK"]="v2l smarc_rzv2l"
+	["RZV2H-EVK"]="v2h v2h_evk_1"
+)
+
+# Resolve PLAT/BOARD for a single PLATFORM
+resolve_board() {
+	local platform="$1"
+	if [[ -z "${P2B[$platform]+set}" ]]; then
+		echo "The platform '$platform' is not supported. Please recheck your setup."
+		exit 1
+	fi
+	read -r PLAT BOARD <<<"${P2B[$platform]}"
+	export PLAT BOARD
+}
+
+mk_image_one() {
+	local platform="$1"
+	local image="$2"
+	resolve_board "${platform}"
+
+	if [ "${ATF_MODE:-RELEASE}" = "DEBUG" ]; then
+		make -C "${ATF_DIR}" -j"${JOBS}" PLAT="${PLAT}" BOARD="${BOARD}" DEBUG=1 "${image}"
+	else
+		make -C "${ATF_DIR}" -j"${JOBS}" PLAT="${PLAT}" BOARD="${BOARD}" "${image}"
+	fi
+}
+
+mk_clean_one() {
+	local platform="$1"
+	resolve_board "${platform}"
+	if [ -d "${out}" ]; then
+		make -C "${ATF_DIR}" clean || true
+	fi
+}
+
+mk_distclean_one() {
+	local platform="$1"
+	resolve_board "${platform}"
+	local out="${BUILD_ROOT}/${PLAT}-${BOARD}"
+	if [ -d "${out}" ]; then
+		make -C "${ATF_DIR}" distclean || true
+		rm -rf "${out}"
+	fi
 }
 
 mk_image() {
-        local image=${1}
-        atf_setup
-
-        if [ "${ATF_MODE}" = "DEBUG" ]; then
-            make -j16 PLAT="${PLAT}" BOARD="${BOARD}" DEBUG=1 "${image}"
-        else
-            make -j16 PLAT="${PLAT}" BOARD="${BOARD}" "${image}"
-        fi
+	local image="$1"
+	if [ "${PLATFORM}" = "RZ-CMN" ]; then
+		for pf in "${COMMON_PLATFORMS[@]}"; do
+			echo "==> Building ${image} for ${pf}"
+			mk_image_one "${pf}" "${image}"
+		done
+	else
+		mk_image_one "${PLATFORM}" "${image}"
+	fi
 }
 
 mk_clean() {
-        make clean
+	if [ "${PLATFORM}" = "RZ-CMN" ]; then
+		for pf in "${COMMON_PLATFORMS[@]}"; do mk_clean_one "${pf}"; done
+	else
+		mk_clean_one "${PLATFORM}"
+	fi
 }
 
 mk_distclean() {
-        make distclean
+	if [ "${PLATFORM}" = "RZ-CMN" ]; then
+		for pf in "${COMMON_PLATFORMS[@]}"; do mk_distclean_one "${pf}"; done
+	else
+		mk_distclean_one "${PLATFORM}"
+	fi
 }
 
-# Main ATF build
-echo "Starting the ATF build ${1} at ${ATF_DIR}"
-cd "${ATF_DIR}" || exit 1
+sanitize_env() {
+	unset CFLAGS LDFLAGS;
+}
 
-case ${1} in
-        'clean')
-                mk_clean
-                ;;
-        'distclean')
-                mk_distclean
-                ;;
-        'bl2')
-                mk_image "${1}"
-                ;;
-        'bl31')
-                mk_image "${1}"
-                ;;
-        'all')
-                mk_image "${1}"
-                ;;
-        *)
-                show_help
-                ;;
+# ---- Main ----
+cmd="${1:-all}"
+echo "Starting the ATF build '${cmd}' (PLATFORM=${PLATFORM}) in ${ATF_DIR}"
+sanitize_env
+
+case "${cmd}" in
+  clean)      mk_clean ;;
+  distclean)  mk_distclean ;;
+  bl2|bl31|all)
+			  mk_image "${cmd}" ;;
+  *)
+			  show_help ;;
 esac
 
 exit 0

--- a/local-build-scripts/build_flash_writer.sh
+++ b/local-build-scripts/build_flash_writer.sh
@@ -3,58 +3,84 @@
 source ./config.ini
 source ./common.sh
 
-# Check Flash-Writer location
-if [ -z "${FLASH_WRITER_DIR}" ]; then
-        echo "There is no U-Boot source at ${FLASH_WRITER_DIR} or it does not set properly at config.ini file."
-        echo "Please recheck your setup"
-        exit 1
+# if PLATFORM is already exported from main_build.sh, keep it
+if [ -n "${PLATFORM:-}" ] && [ -n "${PLAT:-}" ]; then
+	PLATFORM="$PLAT"
 fi
 
-# Setup the build
-flash_writer_setup() {
-        case ${PLATFORM} in
-                'RZG2L-SBC')
-                        BOARD="RZG2L_SBC"
-                        ;;
-                'RZG2L-EVK')
-                        BOARD="RZG2L_SMARC_PMIC"
-                        ;;
-                'RZV2L-EVK')
-                        BOARD="RZV2L_SMARC_PMIC"
-                        ;;
-                'RZV2H-EVK')
-                        BOARD=""
-                        echo "The platform does not support yet. Cancelling the build" || exit 1
-                        ;;
-                *)
-                        echo "The platform does not support. Please recheck your setup" || exit 1
-                        ;;
-        esac
+# Check Flash-Writer location
+if [ -z "${FLASH_WRITER_DIR}" ]; then
+	echo "There is no Flash-writer source at ${FLASH_WRITER_DIR} or it does not set properly at config.ini file."
+	echo "Please recheck your setup"
+	exit 1
+fi
+
+# Map PLATFORM -> "PLAT BOARD"
+declare -A FW_P2B=(
+	["RZG2L-SBC"]="RZG2L_SBC"
+	["RZG2L-EVK"]="RZG2L_SMARC_PMIC"
+	["RZV2L-EVK"]="RZV2L_SMARC_PMIC"
+	["RZV2H-EVK"]="RZV2H_DEV"
+)
+
+sanitize_env() {
+	unset CFLAGS LDFLAGS;
+}
+
+resolve_fw_board() {
+	local platform="$1"
+	if [[ -z "${FW_P2B[$platform]+set}" ]]; then
+		echo "The platform '$platform' is not supported by Flash Writer yet."
+		exit 1
+	fi
+	BOARD="${FW_P2B[$platform]}"
+	export BOARD
+}
+
+mk_image_one() {
+	local platform="$1"
+	sanitize_env
+	resolve_fw_board "${platform}"
+	make -C "${FLASH_WRITER_DIR}" -j"${JOBS}" BOARD="${BOARD}"
+}
+
+mk_clean_one() {
+	local platform="$1"
+	# Clean doesn’t need BOARD in upstream trees, but keep it consistent
+	if [[ -n "${FW_P2B[$platform]+set}" ]]; then
+		BOARD="${FW_P2B[$platform]}"
+		sanitize_env
+		make -C "${FLASH_WRITER_DIR}" clean || true
+	fi
 }
 
 mk_image() {
-        flash_writer_setup
-        make BOARD="${BOARD}" -j16
+	if [ "${PLATFORM}" = "RZ-CMN" ]; then
+		for pf in "${COMMON_PLATFORMS[@]}"; do
+			echo "==> Building Flash Writer for ${pf}"
+			mk_image_one "${pf}"
+		done
+		else
+		mk_image_one "${PLATFORM}"
+	fi
 }
 
 mk_clean() {
-        make clean
+	if [ "${PLATFORM}" = "RZ-CMN" ]; then
+		for pf in "${COMMON_PLATFORMS[@]}"; do mk_clean_one "${pf}"; done
+	else
+		mk_clean_one "${PLATFORM}"
+	fi
 }
 
-# Main Flash-Writer build
-echo "Starting the Flash-Writer build ${1} at ${FLASH_WRITER_DIR}"
-cd "${FLASH_WRITER_DIR}" || exit 1
+# ---- Main ----
+cmd="${1:-all}"
+echo "Starting the Flash-Writer build '${cmd}' (PLATFORM=${PLATFORM}) at ${FLASH_WRITER_DIR}"
 
-case ${1} in
-        'clean')
-                mk_clean
-                ;;
-        'all')
-                mk_image
-                ;;
-        *)
-                show_help
-                ;;
+case "${cmd}" in
+	clean) mk_clean ;;
+	all)   mk_image ;;
+	*)     show_help ;;
 esac
 
 exit 0

--- a/local-build-scripts/build_kernel.sh
+++ b/local-build-scripts/build_kernel.sh
@@ -3,93 +3,118 @@
 source ./config.ini
 source ./common.sh
 
+# if PLATFORM is already exported from main_build.sh, keep it
+if [ -n "${PLATFORM:-}" ] && [ -n "${PLAT:-}" ]; then
+	PLATFORM="$PLAT"
+fi
+
 # Check Linux Kernel location
 if [ -z "${KERNEL_DIR}" ]; then
-        echo "There is no Linux Kernel source at ${KERNEL_DIR} or it does not set properly at config.ini file."
-        echo "Please recheck your setup"
-        exit 1
+	echo "There is no Linux Kernel source at ${KERNEL_DIR} or it does not set properly at config.ini file."
+	echo "Please recheck your setup"
+	exit 1
 fi
+
+# Default fallback
+DEFCONFIG="renesas_defconfig"
+
+# Per-platform mapping
+declare -A KERN_DEFCONFIG=(
+	["RZG2L-SBC"]="rzg2l-sbc_defconfig"
+	["RZG2L-EVK"]="rzv2l_defconfig"
+	["RZV2L-EVK"]="rzv2l_defconfig"
+	["RZV2H-EVK"]="rzv2h_defconfig"
+)
+
+# Resolve DEFCONFIG
+if [[ "${PLATFORM}" == "RZ-CMN" ]]; then
+	DEFCONFIG="renesas_defconfig"
+elif [[ -n "${KERN_DEFCONFIG[$PLATFORM]+x}" ]]; then
+	DEFCONFIG="${KERN_DEFCONFIG[$PLATFORM]}"
+fi
+
+echo "Using DEFCONFIG=${DEFCONFIG}"
 
 # Setup the build
 kernel_setup() {
-        CONFIG_LOCALVERSION='CONFIG_LOCALVERSION="-yocto-standard"'
-        CONFIG_LOCALVERSION_AUTO='CONFIG_LOCALVERSION_AUTO=n'
-        FILE="arch/arm64/configs/defconfig"
+	CONFIG_LOCALVERSION='CONFIG_LOCALVERSION="-yocto-standard"'
+	CONFIG_LOCALVERSION_AUTO='CONFIG_LOCALVERSION_AUTO=n'
+	FILE="arch/arm64/configs/${DEFCONFIG}"
 
-        # Remove '+' at the end of kernel version
-        #touch .scmversion
-        export LOCALVERSION=""
+	# Remove '+' at the end of kernel version
+	#touch .scmversion
+	export LOCALVERSION=""
 
-        # Update defconfig to compatible with rootfs
-        if grep -q "$CONFIG_LOCALVERSION" "$FILE"; then
-                echo "Already set $CONFIG_LOCALVERSION"
-        else
-                echo "$CONFIG_LOCALVERSION" >> "$FILE"
-                echo "Appended $CONFIG_LOCALVERSION to $FILE"
-        fi
+	# Update defconfig to compatible with rootfs
+	if grep -q "$CONFIG_LOCALVERSION" "$FILE"; then
+		echo "Already set $CONFIG_LOCALVERSION"
+	else
+		echo "$CONFIG_LOCALVERSION" >> "$FILE"
+		echo "Appended $CONFIG_LOCALVERSION to $FILE"
+	fi
 
-        if grep -q "$CONFIG_LOCALVERSION_AUTO" "$FILE"; then
-                echo "Already set $CONFIG_LOCALVERSION_AUTO"
-        else
-                echo "$CONFIG_LOCALVERSION_AUTO" >> "$FILE"
-                echo "Appended $CONFIG_LOCALVERSION_AUTO to $FILE"
-        fi
+	if grep -q "$CONFIG_LOCALVERSION_AUTO" "$FILE"; then
+		echo "Already set $CONFIG_LOCALVERSION_AUTO"
+	else
+		echo "$CONFIG_LOCALVERSION_AUTO" >> "$FILE"
+		echo "Appended $CONFIG_LOCALVERSION_AUTO to $FILE"
+	fi
 }
 
 mk_image() {
-        echo '|============================================|'
-        echo '|          Build IMAGE Yocto-standard        |'
-        echo '|============================================|'
-        make -j16 Image
+	echo '|============================================|'
+	echo '|          Build IMAGE Yocto-standard        |'
+	echo '|============================================|'
+	make -j"$(nproc)" Image
 }
 
 mk_dtbs() {
-        echo '|============================================|'
-        echo '|             Build device tree              |'
-        echo '|============================================|'
-        make -j8 dtbs
+	echo '|============================================|'
+	echo '|             Build device tree              |'
+	echo '|============================================|'
+	make -j"$(nproc)" dtbs
 }
 
 mk_full_image() {
-        kernel_setup
-        make defconfig
-        echo '|============================================|'
-        echo '|          Build IMAGE Yocto-standard        |'
-        echo '|============================================|'
-        make -j16 Image
-        echo '|============================================|'
-        echo '|             Build device tree              |'
-        echo '|============================================|'
-        make -j8 dtbs
+	kernel_setup
+	make ${DEFCONFIG}
+	echo '|============================================|'
+	echo '|          Build IMAGE Yocto-standard        |'
+	echo '|============================================|'
+	make -j"$(nproc)" Image
+	echo '|============================================|'
+	echo '|             Build device tree              |'
+	echo '|============================================|'
+	make -j"$(nproc)" dtbs
 }
 
 mk_clean() {
-        make clean
+	make clean
 }
 
 mk_distclean() {
-        make distclean
+	make distclean
 }
 
 mk_defconfig() {
-        kernel_setup
-        make defconfig
+	kernel_setup
+	make defconfig
 }
 
 mk_menuconfig() {
-        kernel_setup
-        make menuconfig
+	kernel_setup
+	make menuconfig
 }
 
 mk_modules() {
-        kernel_setup
-        make defconfig
-        mk_full_image
-        echo '|============================================|'
-        echo '|               Build modules                |'
-        echo '|============================================|'
-        make -j16 modules
-        echo "Build completed successfully"
+	kernel_setup
+	make defconfig
+	mk_full_image
+	echo '|============================================|'
+	echo '|               Build modules                |'
+	echo '|============================================|'
+	make -j"$(nproc)" modules
+	echo "Build completed successfully"
 }
 
 # Main Linux Kernel build
@@ -97,33 +122,35 @@ echo "Starting the kernel build at ${KERNEL_DIR}"
 cd "${KERNEL_DIR}" || exit 1
 
 case ${1} in
-        'clean')
-                mk_clean
-                ;;
-        'distclean')
-                mk_distclean
-                ;;
-        'defconfig')
-                mk_defconfig
-                ;;
-        'menuconfig')
-                mk_menuconfig
-                ;;
-        'image')
-                mk_image
-                ;;
-        'dtbs')
-                mk_dtbs
-                ;;
-        'all')
-                mk_full_image
-                ;;
-        'modules')
-                mk_modules
-                ;;
-        *)
-                show_help
-                ;;
+	'clean')
+		mk_clean
+		;;
+	'distclean')
+		mk_distclean
+		;;
+	'defconfig')
+		mk_defconfig
+		;;
+	'menuconfig')
+		mk_menuconfig
+		;;
+	'image')
+		mk_defconfig
+		mk_image
+		;;
+	'dtbs')
+		mk_defconfig
+		mk_dtbs
+		;;
+	'all')
+		mk_full_image
+		;;
+	'modules')
+		mk_modules
+		;;
+	*)
+		show_help
+		;;
 esac
 
 exit 0

--- a/local-build-scripts/build_uboot.sh
+++ b/local-build-scripts/build_uboot.sh
@@ -3,59 +3,67 @@
 source ./config.ini
 source ./common.sh
 
+# if PLATFORM is already exported from main_build.sh, keep it
+if [ -n "${PLATFORM:-}" ] && [ -n "${PLAT:-}" ]; then
+	PLATFORM="$PLAT"
+fi
+
 # Check U-Boot location
 if [ -z "${UBOOT_DIR}" ]; then
-        echo "There is no U-Boot source at ${UBOOT_DIR} or it does not set properly at config.ini file."
-        echo "Please recheck your setup"
-        exit 1
+	echo "There is no U-Boot source at ${UBOOT_DIR} or it does not set properly at config.ini file."
+	echo "Please recheck your setup"
+	exit 1
 fi
 
 # Setup the build
 uboot_setup() {
-        unset LD_LIBRARY_PATH
-        unset LDFLAGS CFLAGS CPPFLAGS
+	unset LD_LIBRARY_PATH
+	unset LDFLAGS CFLAGS CPPFLAGS
 
-        case ${PLATFORM} in
-                'RZG2L-SBC')
-                        UBOOT_DEFCONFIG="rzpi_defconfig"
-                        ;;
-                'RZG2L-EVK')
-                        UBOOT_DEFCONFIG="smarc-rzg2l_defconfig"
-                        ;;
-                'RZV2L-EVK')
-                        UBOOT_DEFCONFIG="smarc-rzv2l_defconfig"
-                        ;;
-                'RZV2H-EVK')
-                        UBOOT_DEFCONFIG="rzv2h-evk-ver1_defconfig"
-                        ;;
-                *)
-                        echo "The platform does not support. Please recheck your setup" || exit 1
-                        ;;
-        esac        
+	case ${PLATFORM} in
+		'RZG2L-SBC')
+			UBOOT_DEFCONFIG="rzpi_defconfig"
+			;;
+		'RZG2L-EVK')
+			UBOOT_DEFCONFIG="smarc-rzg2l_defconfig"
+			;;
+		'RZV2L-EVK')
+			UBOOT_DEFCONFIG="smarc-rzv2l_defconfig"
+			;;
+		'RZV2H-EVK')
+			UBOOT_DEFCONFIG="rzv2h-evk-ver1_defconfig"
+			;;
+		'RZ-CMN')
+			UBOOT_DEFCONFIG="rz-cmn_defconfig"
+			;;
+		*)
+			echo "The platform does not support. Please recheck your setup" || exit 1
+			;;
+	esac
 }
 
 mk_image() {
-        uboot_setup
-        make -j16
+	uboot_setup
+	make -j"$(nproc)"
 }
 
 mk_full_image() {
-        uboot_setup
-        make "${UBOOT_DEFCONFIG}"
-        make -j16
+	uboot_setup
+	make "${UBOOT_DEFCONFIG}"
+	make -j"$(nproc)"
 }
 
 mk_clean() {
-        make clean
+	make clean
 }
 
 mk_distclean() {
-        make distclean
+	make distclean
 }
 
 mk_defconfig() {
-        uboot_setup
-        make "${UBOOT_DEFCONFIG}"
+	uboot_setup
+	make "${UBOOT_DEFCONFIG}"
 }
 
 # Main U-Boot build
@@ -63,24 +71,24 @@ echo "Starting the U-Boot build ${1} at ${UBOOT_DIR}"
 cd "${UBOOT_DIR}" || exit 1
 
 case ${1} in
-        'clean')
-                mk_clean
-                ;;
-        'distclean')
-                mk_distclean
-                ;;
-        'defconfig')
-                mk_defconfig
-                ;;
-        'image')
-                mk_image
-                ;;
-        'all')
-                mk_full_image
-                ;;
-        *)
-                show_help
-                ;;
+	'clean')
+		mk_clean
+		;;
+	'distclean')
+		mk_distclean
+		;;
+	'defconfig')
+		mk_defconfig
+		;;
+	'image')
+		mk_image
+		;;
+	'all')
+		mk_full_image
+		;;
+	*)
+		show_help
+		;;
 esac
 
 exit 0

--- a/local-build-scripts/common.sh
+++ b/local-build-scripts/common.sh
@@ -60,6 +60,10 @@ For example:
         $ ./main-build.sh kernel clean
 
 Note: Before executing the build, please make sure that you have updated the configuration file: config.ini at the top of the build scripts folder.
+
+Platform Override:
+    By default, PLATFORM is read from config.ini, but you can override it at runtime, for example:
+        $ PLAT=RZ-CMN ./main-build.sh kernel full-image
 "
 # Help message
 show_help() {

--- a/local-build-scripts/config.ini
+++ b/local-build-scripts/config.ini
@@ -2,14 +2,17 @@
 
 # Support platforms
 #PLATFORM=RZG2L-SBC
-PLATFORM=RZG2L-EVK
+#PLATFORM=RZG2L-EVK
 #PLATFORM=RZV2L-EVK
 #PLATFORM=RZV2H-EVK
-#PLATFORM=RZ-CMN (not supported yet)
+PLATFORM=RZ-CMN
+
+# List of platforms for the common build (RZ-CMN)
+COMMON_PLATFORMS=("RZG2L-SBC" "RZG2L-EVK" "RZV2L-EVK" "RZV2H-EVK")
 
 # SDK location
-SDK_LOCATION=/opt/poky/3.1.26
-#SDK_LOCATION=/opt/poky/5.1.1
+#SDK_LOCATION=/opt/poky/3.1.26
+SDK_LOCATION=/opt/poky/5.1.4
 
 # These are the (absolute) input path where the software are located.
 KERNEL_DIR=~/workspace/linux-rz

--- a/local-build-scripts/main_build.sh
+++ b/local-build-scripts/main_build.sh
@@ -5,69 +5,75 @@ source ./common.sh
 
 # POKY setup
 if [ ! -d "${SDK_LOCATION}" ];then
-        echo "There is no installed SDK at ${SDK_LOCATION} or it does not set properly at config.ini file."
-        echo "Please recheck your setup"
-        exit 1
+	echo "There is no installed SDK at ${SDK_LOCATION} or it does not set properly at config.ini file."
+	echo "Please recheck your setup"
+	exit 1
 fi
 
-#TOOLCHAIN=${SDK_LOCATION}/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux
-#export PATH=${TOOLCHAIN}:${PATH}
-#export ARCH=arm64
-#export CROSS_COMPILE=${TOOLCHAIN}/aarch64-poky-linux-
-#export KERNEL_CROSS_COMPILE=${CROSS_COMPILE}
-source ${SDK_LOCATION}/environment-setup-aarch64-poky-linux
+TOOLCHAIN=${SDK_LOCATION}/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux
+export PATH=${TOOLCHAIN}:${PATH}
+export ARCH=arm64
+export CROSS_COMPILE=${TOOLCHAIN}/aarch64-poky-linux-
+export KERNEL_CROSS_COMPILE=${CROSS_COMPILE}
+#source ${SDK_LOCATION}/environment-setup-cortexa55-poky-linux
+
+# Allow PLATFORM override via positional arg
+if [ -n "${PLAT:-}" ]; then
+	PLATFORM="$PLAT"
+	export PLATFORM
+fi
 
 # Main process
 echo "Starting the build script at $(pwd)"
 echo "Target platform ${PLATFORM}"
 if [ -z "${1}" ] ; then
-        show_help
+	show_help
 else
-        if [ -z "${2}" ]; then
-                if [ "${1}" = "build-all" ] || [ "${1}" = "clean-all" ]; then
-                        case ${1} in
-                                "build-all")
-                                        ./build_kernel.sh "all"
-                                        ./build_uboot.sh "all"
-                                        ./build_atf.sh "all"
-                                        ./build_flash_writer.sh "all"
-                                        ;;
-                                "clean-all")
-                                        ./build_kernel.sh "distclean"
-                                        ./build_uboot.sh "distclean"
-                                        ./build_atf.sh "distclean"
-                                        ./build_flash_writer.sh "clean"
-                                        ;;
-                                *)
-                                        show_help
-                                        ;;
-                        esac
-                else
-                        show_help
-                fi
-        else
-                if [ "${1}" = "kernel" ] || [ "${1}" = "uboot" ] || [ "${1}" = "atf" ] || [ "${1}" = "flash-writer" ]; then
-                        case ${1} in
-                                "kernel")
-                                        ./build_kernel.sh "${2}"
-                                        ;;
-                                "uboot")
-                                        ./build_uboot.sh "${2}"
-                                        ;;
-                                "atf")
-                                        ./build_atf.sh "${2}"
-                                        ;;
-                                "flash-writer")
-                                        ./build_flash_writer.sh "${2}"
-                                        ;;
-                                *)
-                                        show_help
-                                        ;;
-                        esac
-                else
-                        show_help
-                fi
-        fi
+	if [ -z "${2}" ]; then
+		if [ "${1}" = "build-all" ] || [ "${1}" = "clean-all" ]; then
+			case ${1} in
+				"build-all")
+					./build_kernel.sh "all"
+					./build_uboot.sh "all"
+					./build_atf.sh "all"
+					./build_flash_writer.sh "all"
+					;;
+				"clean-all")
+					./build_kernel.sh "distclean"
+					./build_uboot.sh "distclean"
+					./build_atf.sh "distclean"
+					./build_flash_writer.sh "clean"
+					;;
+				*)
+					show_help
+					;;
+			esac
+		else
+			show_help
+		fi
+	else
+		if [ "${1}" = "kernel" ] || [ "${1}" = "uboot" ] || [ "${1}" = "atf" ] || [ "${1}" = "flash-writer" ]; then
+			case ${1} in
+				"kernel")
+					./build_kernel.sh "${2}"
+					;;
+				"uboot")
+					./build_uboot.sh "${2}"
+					;;
+				"atf")
+					./build_atf.sh "${2}"
+					;;
+				"flash-writer")
+					./build_flash_writer.sh "${2}"
+					;;
+				*)
+					show_help
+					;;
+			esac
+		else
+			show_help
+		fi
+	fi
 fi
 
 exit 0


### PR DESCRIPTION
Changes include:
- Use tabs instead of space for indentation
- Modify common defconfigs for Linux and U-Boot
- Add a loop to build Flash-writer and TF-A for specific platforms and SoCs