### PR TITLE
local-build-scripts: fix uboot/atf build

### DIFF
--- a/local-build-scripts/build_atf.sh
+++ b/local-build-scripts/build_atf.sh
@@ -53,19 +53,13 @@ mk_image_one() {
 mk_clean_one() {
 	local platform="$1"
 	resolve_board "${platform}"
-	if [ -d "${out}" ]; then
-		make -C "${ATF_DIR}" clean || true
-	fi
+	make -C "${ATF_DIR}" clean || true
 }
 
 mk_distclean_one() {
 	local platform="$1"
 	resolve_board "${platform}"
-	local out="${BUILD_ROOT}/${PLAT}-${BOARD}"
-	if [ -d "${out}" ]; then
-		make -C "${ATF_DIR}" distclean || true
-		rm -rf "${out}"
-	fi
+	make -C "${ATF_DIR}" distclean || true
 }
 
 mk_image() {

--- a/local-build-scripts/build_kernel.sh
+++ b/local-build-scripts/build_kernel.sh
@@ -98,7 +98,7 @@ mk_distclean() {
 
 mk_defconfig() {
 	kernel_setup
-	make defconfig
+	make ${DEFCONFIG}
 }
 
 mk_menuconfig() {
@@ -108,7 +108,7 @@ mk_menuconfig() {
 
 mk_modules() {
 	kernel_setup
-	make defconfig
+	make ${DEFCONFIG}
 	mk_full_image
 	echo '|============================================|'
 	echo '|               Build modules                |'

--- a/local-build-scripts/main_build.sh
+++ b/local-build-scripts/main_build.sh
@@ -11,10 +11,18 @@ if [ ! -d "${SDK_LOCATION}" ];then
 fi
 
 TOOLCHAIN=${SDK_LOCATION}/sysroots/x86_64-pokysdk-linux/usr/bin/aarch64-poky-linux
+export SDKTARGETSYSROOT=${SDK_LOCATION}/sysroots/cortexa55-poky-linux
 export PATH=${TOOLCHAIN}:${PATH}
 export ARCH=arm64
-export CROSS_COMPILE=${TOOLCHAIN}/aarch64-poky-linux-
+export CROSS_COMPILE=aarch64-poky-linux-
 export KERNEL_CROSS_COMPILE=${CROSS_COMPILE}
+export KCFLAGS="--sysroot=$SDKTARGETSYSROOT"
+export OECORE_TUNE_CCARGS=" -mcpu=cortex-a55+crypto -mbranch-protection=standard"
+export CC="aarch64-poky-linux-gcc  -mcpu=cortex-a55+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=$SDKTARGETSYSROOT"
+export CXX="aarch64-poky-linux-g++  -mcpu=cortex-a55+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=$SDKTARGETSYSROOT"
+export CPP="aarch64-poky-linux-gcc -E  -mcpu=cortex-a55+crypto -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=$SDKTARGETSYSROOT"
+export LD="aarch64-poky-linux-ld  --sysroot=$SDKTARGETSYSROOT"
+export AS="aarch64-poky-linux-as "
 #source ${SDK_LOCATION}/environment-setup-cortexa55-poky-linux
 
 # Allow PLATFORM override via positional arg
@@ -29,7 +37,7 @@ echo "Target platform ${PLATFORM}"
 if [ -z "${1}" ] ; then
 	show_help
 else
-	if [ -z "${2}" ]; then
+	if [ -z "${2-}" ]; then
 		if [ "${1}" = "build-all" ] || [ "${1}" = "clean-all" ]; then
 			case ${1} in
 				"build-all")


### PR DESCRIPTION
Add necessary exports and remove unnecessary command so U-Boot and ATF build cleanly with the SDK