### PR TITLE
tools: update platform_info and flash_images JSON files

### DIFF
--- a/tools/binmake/platform_info.json
+++ b/tools/binmake/platform_info.json
@@ -22,7 +22,7 @@
 
         "bl2_desc": [],
         "bl2_dtb_desc": [],
-        "u_boot_desc": ["0", "1", "0", "2", "0x48080000", "0x58000000"],
+        "u_boot_desc": ["1", "1", "0", "2", "0x48080000", "0x58000000"],
         "u_boot_dtb_desc": ["0x48000000"],
         "kernel_desc": [],
         "kernel_dtb_desc": []
@@ -80,7 +80,7 @@
 
         "bl2_desc": [],
         "bl2_dtb_desc": [],
-        "u_boot_desc": ["0", "1", "0", "2", "0x48080000", "0x58000000"],
+        "u_boot_desc": ["1", "1", "0", "2", "0x48080000", "0x58000000"],
         "u_boot_dtb_desc": ["0x48000000"],
         "kernel_desc": [],
         "kernel_dtb_desc": []

--- a/universal-scripts/host/tools/flash_images.json
+++ b/universal-scripts/host/tools/flash_images.json
@@ -42,7 +42,7 @@
         "fip": "fip_rzv2h-evk.srec",
         "atf_fdts": "rzv2h-evk-ver1.dtb",
         "uboot_dtb": "rzv2h-evk-ver1.dtb",
-        "flash_writer": "Flash_Writer_SCIF_RZV2H_DEV_INTERNAL_MEMORY.mot",
+        "flash_writer": "Flash_Writer_SCIF_rzv2h-evk.mot",
         "ipl_flash_method": "xspi",
         "rootfs": "core-image-minimal.wic",
         "rootfs_flash_method": "udp"


### PR DESCRIPTION
Changes include:
- Set mmcdev to 1 for rzv2l-evk and rzg2l-evk boards.
- Correct the flash-writer file name of rzv2h-evk