### PR TITLE
rz-cmn: Move offset for board info in FIP to prevent overwrite

### DIFF
--- a/universal-scripts/host/tools/config/boards_flash_config.toml
+++ b/universal-scripts/host/tools/config/boards_flash_config.toml
@@ -87,8 +87,8 @@ load_address = "0x48000000"
 # Bootloader flash SPI
 [rzv2h-evk.xspi]
 BL2 = ["8101E00", "00000"]
+BID = ["00810", "5F300"]
 FIP = ["00000", "60000"]
-BID = ["00810", "120000"]
 
 # Bootloader flash eMMC
 [rzv2h-evk.emmc]


### PR DESCRIPTION
Prevent board ID overwrite when FIP size increases (due to hardcoded rz-utils offset)