### PR TITLE
rz-cmn: clarify mmc target for fastboot

### DIFF
--- a/universal-scripts/host/tools/README.md
+++ b/universal-scripts/host/tools/README.md
@@ -313,6 +313,16 @@ flowchart TD
   | rzg2l-evk  | 0 |
   | rzv2h-evk  | 0, 1 |
 
+Both fastboot-otg and fastboot-udp write to U-Boot's current MMC device (typically mmc0). Depending on board and revision, mmc0 may point to the SD card or eMMC.
+
+| Board / Rev                                | Fastboot Method | Typical mmc0 target                                                     | How to change target                                           |
+|--------------------------------------------|-----------------|-------------------------------------------------------------------------|----------------------------------------------------------------|
+| rzg2l-sbc                                  | UDP             | Carrier SD (board default)                                              | N/A (single device)                                            |
+| rzv2l-evk                                  | UDP, OTG        | SD (CN10 on SOM or eMMC device depending on SW1)                        | Set SW1-2 ON to SD and OFF to eMMC                             |
+| rzg2l-evk                                  | UDP, OTG        | SD (CN10 on SOM or eMMC device depending on SW1)                        | Set SW1-2 ON to SD and OFF to eMMC                             |
+| rzv2h-evk (rev 1: 2 SD cards)              | UDP, OTG        | SD card slot 0                                                          | N/A (single device)                                            |
+| rzv2h-evk (rev 2: 1 SD & 1 eMMC)           | UDP, OTG        | eMMC                                                                    | N/A (single device)                                            |
+
 ---
 
 ## Basic Usage

--- a/universal-scripts/host/tools/sd_creator/README.md
+++ b/universal-scripts/host/tools/sd_creator/README.md
@@ -103,6 +103,18 @@ Specify the Ethernet device index with `--ether_port` when using `--fastboot_typ
 | rzg2l-evk  | 0 |
 | rzv2h-evk  | 0, 1 |
 
+**Fastboot MMC Target**
+
+Both fastboot-otg and fastboot-udp write to U-Boot's current MMC device (typically mmc0). Depending on board and revision, mmc0 may point to the SD card or eMMC.
+
+| Board / Rev                                | Fastboot Method | Typical mmc0 target                                                     | How to change target                                           |
+|--------------------------------------------|-----------------|-------------------------------------------------------------------------|----------------------------------------------------------------|
+| rzg2l-sbc                                  | UDP             | Carrier SD (board default)                                              | N/A (single device)                                            |
+| rzv2l-evk                                  | UDP, OTG        | SD (CN10 on SOM or eMMC device depending on SW1)                        | Set SW1-2 ON to SD and OFF to eMMC                             |
+| rzg2l-evk                                  | UDP, OTG        | SD (CN10 on SOM or eMMC device depending on SW1)                        | Set SW1-2 ON to SD and OFF to eMMC                             |
+| rzv2h-evk (rev 1: 2 SD cards)              | UDP, OTG        | SD card slot 0                                                          | N/A (single device)                                            |
+| rzv2h-evk (rev 2: 1 SD & 1 eMMC)           | UDP, OTG        | eMMC                                                                    | N/A (single device)                                            |
+
 ---
 
 ## Usage Help


### PR DESCRIPTION
Update Readme to note which SD/eMMC device fastboot uses to burn rootfs and how to switch targets on different boards.