### PR TITLE
uload_bootloader: move offset of board identification

### DIFF
--- a/universal-scripts/host/tools/config/README.md
+++ b/universal-scripts/host/tools/config/README.md
@@ -9,21 +9,27 @@ All the scripts uses a `boards_flash_config.toml` file to define flash layout an
 ## Example Structure
 
 ```toml
-[rzg2l-sbc]
+[rzg2l-evk]
 ethernet = ["11c20000", "11c30000"]
-ethernet_udp_index = 1
+ethernet_udp_index = 0
+bl2_base = "0x12000"
+fconf_dtb_base = "0x2A000"
+
+# Uload bootloader
 flash_address = ["00000", "1D200", "1C700"]
 load_address = "0x48000000"
 
-[rzg2l-sbc.xspi]
+# Bootloader flash SPI
+[rzg2l-evk.xspi]
 BL2 = ["11E00", "00000"]
 FIP = ["00000", "1D200"]
 BID = ["00810", "1C700"]
 
-[rzg2l-sbc.emmc]
+# Bootloader flash eMMC
+[rzg2l-evk.emmc]
 BL2 = ["1", "1", "11E00"]
 FIP = ["1", "100", "00000", "2", "8"]
-BID = ["1", "200", "1C700", "250", "122"]
+BID = ["1", "FA", "810"]
 ```
 
 ## How to support new board to script
@@ -36,18 +42,20 @@ bl2_base = "<bl2_base_address>"
 fconf_dtb_base = "<fconf_dtb_base_address>"
 ethernet = ["<eth0_address>", "eth1_address"]
 ethernet_udp_index = <port_index_or_list>
+
+# Uload bootloader
 flash_address = ["<bl2>", "<fip>", "<board_information>"]
 load_address = "<working_ram>"
 
 [<board_name>.xspi]
-"BL2": ["<srec_top_address>", "<flash_address>"]
-"FIP": ["<srec_top_address>", "<flash_address>"]
-"BID": ["<binary_size (.bin) / srec_top_address (.srec)>", "<flash_address>"]
+"BL2" = ["<srec_top_address>", "<flash_address>"]
+"FIP" = ["<srec_top_address>", "<flash_address>"]
+"BID" = ["<binary_size (.bin) / srec_top_address (.srec)>", "<flash_address>"]
 
 [<board_name>.emmc]
-"BL2": ["<area>", "<sector_start>", "<program_start_address>"]
-"FIP": ["<area>", "<sector_start>", "<program_start_address>", "<ext_csd_b1>", "<ext_csd_b3>"]
-"BID": ["<area>", "<sector_start>", "<program_start_address>", "<ext_csd_b1>", "<ext_csd_b3>"]
+"BL2" = ["<area>", "<sector_start>", "<program_start_address>"]
+"FIP" = ["<area>", "<sector_start>", "<program_start_address>", "<ext_csd_b1>", "<ext_csd_b3>"]
+"BID" = ["<area>", "<sector_start>", "<file_size_in_bytes>"]
 ```
 
 Each board has a dedicated section for its specific configuration. The available setting types are as follows:
@@ -70,3 +78,8 @@ Each board has a dedicated section for its specific configuration. The available
   - BL2: Specify `area`, `sector_start`, and `program_start_address` sequentially for the BL2 image.
   - FIP: Specify `area`, `sector_start`, `program_start_address`, `ext_csd_b1`, and `ext_csd_b3` sequentially for the FIP image.
   - BID: Provide `area`, `sector_start`, `program_start_address`, `ext_csd_b1`, and `ext_csd_b3` sequentially for the board identification image.
+
+> [!NOTE]
+> Entries in `boards_flash_config.toml` are configuration definitions used by the scripts and may also serve as templates for future development.
+> The presence of a board section or a boot media subsection does **not** necessarily mean that flashing for that board/method is currently supported, implemented, or validated.
+> For the list of officially supported boards and IPL flashing methods, refer to [the supported IPL flashing table](../README.md)

--- a/universal-scripts/host/tools/config/boards_flash_config.toml
+++ b/universal-scripts/host/tools/config/boards_flash_config.toml
@@ -17,12 +17,6 @@ BL2 = ["11E00", "00000"]
 FIP = ["00000", "1D200"]
 BID = ["00810", "1C700"]
 
-# Bootloader flash eMMC
-[rzg2l-sbc.emmc]
-BL2 = ["1", "1", "11E00"]
-FIP = ["1", "100", "00000", "2", "8"]
-BID = ["1", "FA", "810"]
-
 ####################################
 # RZ/G2L EVK board configurations
 ####################################
@@ -110,7 +104,7 @@ bl2_base = "0x8103000"
 fconf_dtb_base = "0x08130000"
 
 # Uload bootloader
-flash_address = ["00000", "60000", "120000"]
+flash_address = ["00000", "60000", "5F300"]
 load_address = "0x48000000"
 
 # Bootloader flash SPI
@@ -122,8 +116,8 @@ FIP = ["00000", "60000"]
 # Bootloader flash eMMC
 [rzv2h-evk.emmc]
 BL2 = ["1", "1", "8101E00"]
-FIP = ["1", "100", "00000", "2", "8"]
-BID = ["1", "200", "120000", "762", "762"]
+FIP = ["1", "300", "44000000", "2", "8"]
+BID = ["1", "2FA", "810"]
 
 ####################################
 # RZ/V2H RDK board configurations
@@ -137,7 +131,7 @@ bl2_base = "0x8103000"
 fconf_dtb_base = "0x08130000"
 
 # Uload bootloader
-flash_address = ["00000", "60000", "120000"]
+flash_address = ["00000", "60000", "5F300"]
 load_address = "0x48000000"
 
 # Bootloader flash SPI
@@ -145,6 +139,11 @@ load_address = "0x48000000"
 BL2 = ["8101E00", "00000"]
 BID = ["00810", "5F300"]
 FIP = ["00000", "60000"]
+
+[rzv2h-rdk.emmc]
+BL2 = ["1", "1", "8101E00"]
+FIP = ["1", "300", "44000000", "2", "8"]
+BID = ["1", "2FA", "810"]
 
 ####################################
 # IMDT V2H Single Board Computer configurations
@@ -158,7 +157,7 @@ bl2_base = "0x8103000"
 fconf_dtb_base = "0x08130000"
 
 # Uload bootloader
-flash_address = ["00000", "60000", "120000"]
+flash_address = ["00000", "60000", "5F300"]
 load_address = "0x48000000"
 
 # Bootloader flash SPI
@@ -170,5 +169,5 @@ FIP = ["00000", "60000"]
 # Bootloader flash eMMC
 [imdt-v2h-sbc.emmc]
 BL2 = ["1", "1", "8101E00"]
-FIP = ["1", "100", "00000", "2", "8"]
-BID = ["1", "200", "120000", "762", "762"]
+FIP = ["1", "300", "44000000", "2", "8"]
+BID = ["1", "2FA", "810"]

--- a/universal-scripts/host/tools/firmware_compile/Readme.md
+++ b/universal-scripts/host/tools/firmware_compile/Readme.md
@@ -4,8 +4,8 @@
 `firmware-compile.py` is a helper script for building Renesas RZ family firmware artifacts, including **BL2**, **Boot Parameter (BP)** files, **U-Boot** binaries, and **FIP** packages.  
 
 It automatically pulls board and flash-method–specific configuration (such as VMA addresses) from:
-- [`boards_flash_config.toml`](tools/config/boards_flash_config.toml or config/boards_flash_config.toml)  
-- [`flash_images.json`](target/images/flash_images.json)  
+- [`boards_flash_config.toml`](../config/boards_flash_config.toml)  
+- [`flash_images.json`](../flash_images.json)  
 
 The script supports multiple boards and flash methods without hardcoding addresses.
 

--- a/universal-scripts/host/tools/universal_flash.py
+++ b/universal-scripts/host/tools/universal_flash.py
@@ -295,7 +295,8 @@ class UniversalFlashUtil:
                 uload_bootloader_args = [
                     '--board_name', f"{self.selected_board_name}",
                     '--serial_port', f"{self.selected_port}",
-                    '--serial_port_baud', f"{self.selected_baud_rate}"
+                    '--serial_port_baud', f"{self.selected_baud_rate}",
+                    '--image_bid', f"{self.selected_info.board_identification}"
                 ]
                 uloadFlashUtil = UloadFlashUtil(args=uload_bootloader_args)
                 uloadFlashUtil.writeUloadBootloader()


### PR DESCRIPTION
Prevent board ID overwrite when FIP size increases for uload-bootloader

Related PR: 

1. https://github.com/Renesas-SST/rz-utils/pull/18
2. https://github.com/Renesas-SST/u-boot/pull/25