### PR TITLE
tools: add RDK offical release link and clarify reset behavior

### DIFF
--- a/universal-scripts/host/tools/README.md
+++ b/universal-scripts/host/tools/README.md
@@ -16,7 +16,7 @@ Supported boards:
 - [RS-G2L100](https://www.renesas.com/en/products/microcontrollers-microprocessors/rz-mpus/rz-partner-solutions/geniatech-g2l100)
 - [RZV2L-EVK](https://www.renesas.com/en/design-resources/boards-kits/rz-v2l-evkit?srsltid=AfmBOooz3AGWNCJNed1qk6NS0qeZBngU79XQ4h2KUkmMam82y615JPjr)
 - [RZV2H-EVK](https://www.renesas.com/en/design-resources/boards-kits/rz-v2h-evk?srsltid=AfmBOooL-eoj5j3zum-HIL5v0JE9SROaKosWHYCOHfvySpJ4g39N9R_V)
-- [RZV2H-RDK](Product page not yet available)
+- [RZV2H-RDK](https://www.renesas.com/en/design-resources/boards-kits/ws125-v2hrdkrefz)
 - [IMDT V2H-SBC](https://www.renesas.com/en/products/microcontrollers-microprocessors/rz-mpus/rz-partner-solutions/imdt-v2-sbc)
 
 ## Prerequisites:
@@ -323,13 +323,19 @@ Refer to the [Basic Usage](#basic-usage) section for commands to run the tool.
 - Insert the SD card if rootfs flashing is selected.
 - For Bootloader-flash: set boot switches to SCIF download mode.
 - For Uload-flash or rootfs flashing: set boot switches to normal mode.
-- **Board Reset/Power-cycle:**
-  - **RZ/G2L-SBC**: Does not have a RESET button. You must power-cycle by unplugging and re-plugging the power adapter. Since the debug/OTG USB port is powered from the same power jack, the USB device will disconnect and the serial port will disappear from the host PC during power-cycle. Ensure you reconnect the USB cable to the same PC port after power-cycle to avoid reconnection issues.
-  - **RZ/G2L-EVK, RZ/V2L-EVK boards**: Use the RESET button to reset the board without removing power. The USB connection and serial port remain available during flashing.
-  - **RS-G2L100**: Does not have a RESET button. You must power-cycle by unplugging and re-plugging the power adapter. Since the debug/OTG USB port is powered from the same power jack, the USB device will disconnect and the serial port will disappear from the host PC during power-cycle. Ensure you reconnect the USB cable to the same PC port after power-cycle to avoid reconnection issues.
-  - **RZ/V2H-EVK**: Use the RESET button to reset the board without removing power. The USB connection and serial port remain available during flashing.
-  - **RZ/V2H-RDK board**: Does not have a RESET button. You must power-cycle by unplugging and re-plugging the power adapter. Since the debug/OTG USB port is powered from the same power jack, the USB device will disconnect and the serial port will disappear from the host PC during power-cycle. Ensure you reconnect the USB cable to the same PC port after power-cycle to avoid reconnection issues.
-  - **IMDT V2H-SBC**: Use the RESET button to reset the board without removing power. The USB connection and serial port remain available during flashing.
+- **Reset and power-cycle behavior by board:**
+  - **RZ/G2L-SBC**
+    This board does not provide a dedicated **RESET** button. To restart the board or apply a boot mode change, you must power-cycle it.
+  - **RZ/G2L-EVK** and **RZ/V2L-EVK**
+    These boards provide a **RESET** button. You can reset the board without removing power, and the USB connection and serial port typically remain available.
+  - **RS-G2L100**
+    This board does not provide a dedicated **RESET** button. To restart the board or apply a boot mode change, you must power-cycle it.
+  - **RZ/V2H-EVK**
+    This board provides a **RESET** button. You can reset the board without removing power, and the USB connection and serial port typically remain available.
+  - **RZ/V2H-RDK**
+    This board does not provide a dedicated **RESET** button. To restart the board or apply a boot mode change, you must power-cycle it by unplugging and reconnecting the power adapter. Because the USB serial interface is powered from the same source, the USB device disconnects during power-cycle and the serial port disappears from the host PC. When power-cycling the board, keep the USB cable connected to the same USB port on the host PC to avoid enumeration or reconnection issues.
+  - **IMDT V2H-SBC**
+    This board provides a **RESET** button. You can reset the board without removing power, and the USB connection and serial port typically remain available.
 - Rootfs flash (UDP Fastboot): U-Boot fastboot-udp uses a single active Ethernet MAC per board. If multiple RJ45/PHY ports exist, only one is active (depending on board support). The script automatically selects the appropriate Ethernet port based on board configuration in `boards_flash_config.toml`. For boards with multiple available ports, the script will prompt you to select which port to use.
 
   | Board         | Ethernet port(s) used |

--- a/universal-scripts/host/tools/sd_creator/README.md
+++ b/universal-scripts/host/tools/sd_creator/README.md
@@ -109,13 +109,15 @@ Specify the Ethernet device index with `--ether_port` when using `--fastboot_typ
 | rzv2h-rdk  | 0 |
 | imdt-v2h-sbc  | 0, 1 |
 
-> **Note for rzv2h-rdk board:**
-> 
-> The RZ/V2H-RDK board does not have a RESET button. To reset the board, you must power-cycle by unplugging and re-plugging the power adapter. Since the debug/OTG USB port and the board's main power are supplied through the same power jack, the USB device will disconnect during power-cycle, and the serial port will disappear from the host PC.
-> 
-> In contrast, RZ/{G,V}2L-EVK boards provide a RESET button, which allows you to reset the board without removing power, so the USB connection and serial port remain available during flashing.
-> 
-> When performing a power-cycle on RZ/V2H-RDK, make sure not to change the USB port or cable on your PC, and always reconnect both the power and USB exactly as before to avoid reconnection issues during flashing or debugging.
+> **Note for RZ/V2H-RDK:**
+>
+> - This board does not provide a dedicated **RESET** button. To restart the board or apply a boot mode change, you must power-cycle it by unplugging and reconnecting the power adapter.
+>
+> - On RZ/V2H-RDK, the USB serial port is powered from the same source as the board. As a result, the USB device disconnects during power-cycle and the serial port disappears temporarily from the host PC before re-enumerating.
+>
+> - USB and serial-port behavior during reset or power-cycle depends on the hardware design of each board. Some boards keep the USB serial interface available during reset, while others disconnect and re-enumerate on the host.
+>
+> - When power-cycling RZ/V2H-RDK, keep the same USB cable connected to the same host USB port to help avoid re-enumeration or reconnection issues during flashing or debugging.
 
 **Fastboot MMC Target**
 


### PR DESCRIPTION
Add the official RZ/V2H-RDK release link to the documentation and clarify reset and power-cycle behavior for all supported boards.