### PR TITLE
rz-cmn: add sparrow-hawk (RZ/V4H) board support

### DIFF
--- a/tools/binmake/platform_info.json
+++ b/tools/binmake/platform_info.json
@@ -229,5 +229,34 @@
         "u_boot_dtb_desc": ["0x48000000"],
         "kernel_desc": [],
         "kernel_dtb_desc": []
+    },
+
+    "sparrow-hawk": {
+        "model_id": 64,
+        "revision_minor": 0,
+        "revision_major": 1,
+        "model_string": "sparrow-hawk",
+        "mfg_name": "Renesas",
+
+        "bl2_loc": 0,
+        "bl2_dtb_loc": 0,
+        "u_boot_loc": 3,
+        "u_boot_dtb_loc": 3,
+        "kernel_loc": 1,
+        "kernel_dtb_loc": 1,
+
+        "bl2_id": 2,
+        "bl2_dtb_id": 3,
+        "u_boot_id": 6,
+        "u_boot_dtb_id": 7,
+        "kernel_id": 14,
+        "kernel_dtb_id": 15,
+
+        "bl2_desc": [],
+        "bl2_dtb_desc": [],
+        "u_boot_desc": ["0", "1", "0", "2", "0x48080000", "0x58000000"],
+        "u_boot_dtb_desc": ["0x48000000", "0x48020000"],
+        "kernel_desc": [],
+        "kernel_dtb_desc": []
     }
 }

--- a/universal-scripts/host/tools/config/boards_flash_config.toml
+++ b/universal-scripts/host/tools/config/boards_flash_config.toml
@@ -198,3 +198,37 @@ FIP = ["00000", "60000"]
 BL2 = ["1", "1", "8101E00"]
 FIP = ["1", "300", "44000000", "2", "8"]
 BID = ["1", "2FA", "810"]
+
+####################################
+# RZ/V4H Sparrow-Hawk board configurations
+####################################
+
+[sparrow-hawk]
+ethernet = ["15c20000", "15c30000"]  # TODO: verify Ethernet MAC base for V4H R8A779G0
+ethernet_udp_index = ["0", "1"]
+bl2_dest  = "0x08103000"
+bl2_base = "0x8103000"
+fconf_dtb_base = "0x08130000"
+
+# Uload bootloader
+flash_address = ["00000", "60000", "5F300"]
+load_address = "0x48000000"
+
+# Bootloader flash SPI
+[sparrow-hawk.xspi]
+BL2 = ["8101E00", "00000"]
+BID = ["00810", "5F300"]
+FIP = ["00000", "60000"]
+
+# Bootloader flash eMMC
+[sparrow-hawk.emmc]
+BL2 = ["1", "1", "8101E00"]
+FIP = ["1", "300", "44000000", "2", "8"]
+BID = ["1", "2FA", "810"]
+
+# Bootloader flash eSD
+[sparrow-hawk.esd]
+BL2_BP_ESD = ["1", "1"]
+BL2 = ["8"]
+BID = ["762"]
+FIP = ["768"]

--- a/universal-scripts/host/tools/firmware_compile/firmware_compile.py
+++ b/universal-scripts/host/tools/firmware_compile/firmware_compile.py
@@ -133,6 +133,8 @@ class FirmwareBuilder:
 
 		# Defaults derived from target/images + board
 		self.soc = (args.soc or self.boards_data[self.board]["soc"] or "g2l").lower()
+		# V4H uses the same boot-parameter format as V2H (R-Car Gen4 AA55FFFF record)
+		self.bpgen_soc = "v2h" if self.soc == "v4h" else self.soc
 		self.method = (args.method or self.boards_data[self.board]["ipl_flash_method"] or "xspi").lower()
 
 		default_bl2   = IMG_DIR / "atf"    / f"bl2-{self.method}-rz-cmn.bin"
@@ -263,9 +265,9 @@ class FirmwareBuilder:
 	def step_bootparameter_and_srec(self):
 		"""Generate boot parameter, append BL2+ATF-FDTs, and convert to SREC."""
 		print(f"[build] bootparameter -> {self.bl2_bp.name}")
-		bp_cmd = [str(self.tools.bootparameter), "--soc", self.soc,
+		bp_cmd = [str(self.tools.bootparameter), "--soc", self.bpgen_soc,
 				"--image", str(self.bl2_out), "-o", str(self.bl2_bp)]
-		if self.soc == "v2h":
+		if self.bpgen_soc == "v2h":
 			bp_cmd += ["--mode", self.method, "--dest", self.bl2_dest]
 
 		subprocess.check_call(bp_cmd)
@@ -346,7 +348,7 @@ def parse_args(argv=None) -> argparse.Namespace:
 	"""Parse command-line arguments for firmware_build.py."""
 	p = argparse.ArgumentParser(description="Build BL2/BL2_BP/U-Boot/FIP artifacts (VMAs from TOML per board/method).")
 	p.add_argument("--board", default="rzg2l-sbc")
-	p.add_argument("--soc", choices=["g2l", "v2l", "v2h"],
+	p.add_argument("--soc", choices=["g2l", "v2l", "v2h", "v4h"],
 				help="Target SoC family")
 	p.add_argument("--method", choices=['emmc', 'xspi', 'esd'],
 				help="Which flash method's VMA rules to use (default: xspi)")

--- a/universal-scripts/host/tools/flash_images.json
+++ b/universal-scripts/host/tools/flash_images.json
@@ -89,5 +89,18 @@
         "ipl_flash_method": "xspi",
         "rootfs": "core-image-minimal.wic",
         "rootfs_flash_method": "otg"
+    },
+    "sparrow-hawk": {
+        "soc": "v2h",
+        "bl2": "bl2_bp_sparrow-hawk.srec",
+        "board_identification": "sparrow-hawk-platform-settings.bin",
+        "fip": "fip_sparrow-hawk.srec",
+        "tee": "tee-rz-cmn-v4h.bin",
+        "atf_fdts": "r8a779g3-sparrow-hawk.dtb",
+        "uboot_dtb": "r8a779g3-sparrow-hawk.dtb",
+        "flash_writer": "Flash_Writer_SCIF_sparrow-hawk.mot",
+        "ipl_flash_method": "xspi",
+        "rootfs": "core-image-minimal.wic",
+        "rootfs_flash_method": "otg"
     }
 }


### PR DESCRIPTION
Changes include:
- platform_info.json: add sparrow-hawk entry (model_id=64, V2H memory layout pattern; u_boot_desc/dtb_desc from rzv2h-evk-ver1)
- flash_images.json: add sparrow-hawk entry (soc=v2h for bpgen compat, tee=tee-rz-cmn-v4h.bin, atf_fdts/uboot_dtb=r8a779g3-sparrow-hawk.dtb)
- boards_flash_config.toml: add [sparrow-hawk] section with xSPI/eMMC/eSD flash configs following rzv2h-evk pattern (bl2_dest=0x08103000)
- firmware_compile.py: add v4h to --soc choices; map v4h->v2h internally for bpgen (R-Car Gen4 V4H uses same AA55FFFF boot-parameter format)